### PR TITLE
Removed the Man

### DIFF
--- a/locations/submaps_groups.json
+++ b/locations/submaps_groups.json
@@ -584,8 +584,7 @@
 { "name": "4F - Defeat Team Galactic (Event)", "ref": "Galactic Building/4F - Defeat Team Galactic (Event)"}]},
 { "name": "Amity Square (Left)", "map_locations": [ { "map": "hearthomecity", "x": 176, "y": 128}], "sections": [
 { "name": "Left - Item Near Center Warp", "ref": "Amity Square/Left - Item Near Center Warp"},
-{ "name": "Left - Item on Middle of Island", "ref": "Amity Square/Left - Item on Middle of Island"},
-{ "name": "Berry or Accessory from Man in Random Spot", "ref": "Amity Square/Berry or Accessory from Man in Random Spot"}]},
+{ "name": "Left - Item on Middle of Island", "ref": "Amity Square/Left - Item on Middle of Island"}]},
 { "name": "Amity Square (Right)", "map_locations": [ { "map": "hearthomecity", "x": 848, "y": 128}], "sections": [
 { "name": "Right - Item Behind Bench", "ref": "Amity Square/Right - Item Behind Bench"},
 { "name": "Right - Item Reached with East Warps", "ref": "Amity Square/Right - Item Reached with East Warps"},


### PR DESCRIPTION
The randomly moving NPC in Amity Square is only accessible from entering the right side. just took him out of the left entrance group.

If someone could tell me how i can change where i want a PR merged to so next time i make an oopsie and accidentally put a PR for main, I can change it to the beta branch without having to remake it