### PR TITLE
Vertical Layout Update

### DIFF
--- a/layouts/events.json
+++ b/layouts/events.json
@@ -78,9 +78,6 @@
                     ],
                     [
                         "event_clear_starkmountain",
-                        "event_roamer_1",
-                        "event_roamer_0",
-                        "event_roamer_3",
                         "event_clear_distortion"
                     ]
                 ]


### PR DESCRIPTION
the vertical layout still had the three roamer events in the sidebar. Just removed them to match the horizontal layout