### PR TITLE
fixed access rules for route 227 trainers

### DIFF
--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -3068,7 +3068,7 @@
             {
                 "name": "Ace Trainer Saul",
                 "access_rules": [
-                    "@route_227_lower"
+                    "@route_227"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -3079,7 +3079,7 @@
             {
                 "name": "Ace Trainer Mikayla",
                 "access_rules": [
-                    "@route_227_lower"
+                    "@route_227"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -3101,7 +3101,7 @@
             {
                 "name": "Ranger Felicia",
                 "access_rules": [
-                    "@route_227_lower"
+                    "@route_227"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",


### PR DESCRIPTION
changed the three trainers to be part of route_227 instead of route_227_lower, this is so the bike is required to reach them  