### PR TITLE
Added credits to split tabs

### DIFF
--- a/layouts/tabs_reverse.json
+++ b/layouts/tabs_reverse.json
@@ -30,6 +30,15 @@
                                             }
                                         ]
                                     }
+                                },
+                                {
+                                    "title": "",
+                                    "content": {
+                                        "type": "map",
+                                        "maps": [
+                                            "Credits"
+                                        ]
+                                    }
                                 }
                             ]
                         },

--- a/layouts/tabs_split.json
+++ b/layouts/tabs_split.json
@@ -83,6 +83,15 @@
                                             }
                                         ]
                                     }
+                                },
+                                {
+                                    "title": "",
+                                    "content": {
+                                        "type": "map",
+                                        "maps": [
+                                            "Credits"
+                                        ]
+                                    }
                                 }
                             ]
                         }


### PR DESCRIPTION
saw it wasn't working if set to split or reverse split after some discussion on the RB tracker's credits map. not sure if this is even wanted, so if its not just close it, it took 2 seconds to make