### PR TITLE
Fixing victory road encounter requirements

### DIFF
--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -1873,7 +1873,7 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@victory_road_1f, ^$land_encounters"
+                    "@victory_road_1f_entrance, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"
@@ -1885,7 +1885,7 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@victory_road_2f, ^$land_encounters"
+                    "@victory_road_2f_entrance, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"


### PR DESCRIPTION
victory_road_1f and victory_road_2f are areas that require rock smash to access. You can get both of these floors' encounters with victory_road_1f_entrance and victory_road_2f_entrance both of which do not require rock smash. No issue on AP just tracker