### PR TITLE
Attempting to redo vr regions

### DIFF
--- a/locations/access.json
+++ b/locations/access.json
@@ -3465,8 +3465,8 @@
     {
         "name": "victory_road_1f_room_2",
         "access_rules": [
-            "@victory_road_1f_room_2_entrance, ^$soft_defog, $strength",
-            "@victory_road_1f_room_3, ^$soft_defog"
+            "@victory_road_1f_room_2_entrance, $strength",
+            "@victory_road_1f_room_3"
         ]
     },
     {
@@ -3501,7 +3501,7 @@
         "name": "victory_road_b1f_upper",
         "access_rules": [
             "@victory_road_1f",
-            "@victory_road_b1f, $waterfall"
+            "@victory_road_b1f, $surf, $waterfall"
         ]
     },
     {

--- a/locations/access.json
+++ b/locations/access.json
@@ -3406,32 +3406,29 @@
             "@victory_road_2f_north_alcove"
         ]
     },
-       {
+    {
         "name": "victory_road_1f_center",
         "access_rules": [
             "@victory_road_1f",
             "@victory_road_2f_from_1f",
             "@victory_road_b1f",
         ]
-    }, 
-        {
+    },
+    {
         "name": "victory_road_2f_from_1f",
         "access_rules": [
             "@victory_road_1f_center",
             "@victory_road_2f_from_1f_strength"
-            
         ]
     },
-        }, 
-        {
+    {
         "name": "victory_road_2f_from_1f_strength",
         "access_rules": [
             "@victory_road_2f",
             "@victory_road_2f_from_1f, $strength"
         ]
     },
-        }, 
-        {
+    {
         "name": "victory_road_2f_north_alcove",
         "access_rules": [
             "@victory_road_1f"
@@ -3452,7 +3449,7 @@
             "@victory_road_1f_room_2_entrance, event_defeat_cynthia, national_dex, ^$soft_defog @pokemon_league_hall_of_fame"
         ]
     },
-        {
+    {
         "name": "victory_road_1f_room_2_entrance",
         "access_rules": [
             "@victory_road_1f_room_1, ^$soft_defog",
@@ -3494,7 +3491,7 @@
             "@Victory_road_b1f_upper"
         ]
     },
-        {
+    {
         "name": "victory_road_b1f_upper",
         "access_rules": [
             "@victory_road_1f",

--- a/locations/access.json
+++ b/locations/access.json
@@ -3451,15 +3451,15 @@
     {
         "name": "victory_road_1f_room_1",
         "access_rules": [
-            "@victory_road_1f, event_defeat_cynthia, national_dex, @pokemon_league_hall_of_fame",
-            "@victory_road_1f_room_2_entrance, event_defeat_cynthia, national_dex, ^$soft_defog, @pokemon_league_hall_of_fame"
+            "@victory_road_1f, event_defeat_cynthia, national_dex",
+            "@victory_road_1f_room_2_entrance, event_defeat_cynthia, national_dex"
         ]
     },
     {
         "name": "victory_road_1f_room_2_entrance",
         "access_rules": [
             "@victory_road_1f_room_1, ^$soft_defog",
-            "@victory_road_1f_room_2, ^$soft_defog"
+            "@victory_road_1f_room_2"
         ]
     },
     {

--- a/locations/access.json
+++ b/locations/access.json
@@ -1658,7 +1658,7 @@
         "name": "pokemon_league",
         "access_rules": [
             "@pokemon_league_north_pokecenter_1f",
-            "@victory_road_1f"
+            "@victory_road_1f_upper_entrance"
         ]
     },
     {
@@ -1770,7 +1770,6 @@
         "access_rules": [
             "@pokemon_league_south_pokecenter_1f",
             "@pokemon_league_south_south, $surf, $waterfall",
-            "@victory_road_1f",
             "@victory_road_1f_entrance"
         ]
     },
@@ -3412,6 +3411,13 @@
             "@victory_road_1f",
             "@victory_road_2f_from_1f",
             "@victory_road_b1f",
+        ]
+    },
+    {
+        "name": "victory_road_1f_upper_entrance",
+        "access_rules": [
+            "@pokemon_league, $surf, $down_waterfall",
+            "@victory_road_1f, $rock_climb",
         ]
     },
     {

--- a/locations/access.json
+++ b/locations/access.json
@@ -3452,7 +3452,7 @@
         "name": "victory_road_1f_room_1",
         "access_rules": [
             "@victory_road_1f, event_defeat_cynthia, national_dex, @pokemon_league_hall_of_fame",
-            "@victory_road_1f_room_2_entrance, event_defeat_cynthia, national_dex, ^$soft_defog @pokemon_league_hall_of_fame"
+            "@victory_road_1f_room_2_entrance, event_defeat_cynthia, national_dex, ^$soft_defog, @pokemon_league_hall_of_fame"
         ]
     },
     {

--- a/locations/access.json
+++ b/locations/access.json
@@ -3409,7 +3409,7 @@
         "name": "victory_road_1f_center",
         "access_rules": [
             "@victory_road_1f",
-            "@victory_road_2f",
+            "@victory_road_2f_from_1f",
             "@victory_road_b1f",
         ]
     },

--- a/locations/access.json
+++ b/locations/access.json
@@ -3409,7 +3409,7 @@
         "name": "victory_road_1f_center",
         "access_rules": [
             "@victory_road_1f",
-            "@victory_road_2f_from_1f",
+            "@victory_road_2f",
             "@victory_road_b1f",
         ]
     },

--- a/locations/access.json
+++ b/locations/access.json
@@ -3494,7 +3494,7 @@
         "name": "victory_road_b1f",
         "access_rules": [
             "@victory_road_1f_center",
-            "@Victory_road_b1f_upper"
+            "@victory_road_b1f_upper"
         ]
     },
     {

--- a/locations/access.json
+++ b/locations/access.json
@@ -1797,7 +1797,7 @@
     {
         "name": "pokemon_league_south_south",
         "access_rules": [
-            "@pokemon_league_south",
+            "@pokemon_league_south, $surf, $down_waterfall",
             "@route_223, $surf"
         ]
     },

--- a/locations/access.json
+++ b/locations/access.json
@@ -3400,31 +3400,70 @@
     {
         "name": "victory_road_1f",
         "access_rules": [
-            "@pokemon_league",
+            "@victory_road_1f_upper_entrance, $rock_climb",
             "@victory_road_1f_room_1",
+            "@victory_road_b1f_upper",
+            "@victory_road_2f_north_alcove"
+        ]
+    },
+       {
+        "name": "victory_road_1f_center",
+        "access_rules": [
+            "@victory_road_1f",
+            "@victory_road_2f_from_1f",
+            "@victory_road_b1f",
+        ]
+    }, 
+        {
+        "name": "victory_road_2f_from_1f",
+        "access_rules": [
+            "@victory_road_1f_center",
+            "@victory_road_2f_from_1f_strength"
+            
+        ]
+    },
+        }, 
+        {
+        "name": "victory_road_2f_from_1f_strength",
+        "access_rules": [
             "@victory_road_2f",
-            "@victory_road_b1f"
+            "@victory_road_2f_from_1f, $strength"
+        ]
+    },
+        }, 
+        {
+        "name": "victory_road_2f_north_alcove",
+        "access_rules": [
+            "@victory_road_1f"
         ]
     },
     {
         "name": "victory_road_1f_entrance",
         "access_rules": [
             "@pokemon_league_south",
+            "@victory_road_1f_center",
             "@victory_road_2f_entrance"
         ]
     },
     {
         "name": "victory_road_1f_room_1",
         "access_rules": [
-            "@victory_road_1f, event_defeat_cynthia, national_dex, ^$soft_defog, @pokemon_league_hall_of_fame",
-            "@victory_road_1f_room_2, event_defeat_cynthia, national_dex, ^$soft_defog, @pokemon_league_hall_of_fame"
+            "@victory_road_1f, event_defeat_cynthia, national_dex, @pokemon_league_hall_of_fame",
+            "@victory_road_1f_room_2_entrance, event_defeat_cynthia, national_dex, ^$soft_defog @pokemon_league_hall_of_fame"
+        ]
+    },
+        {
+        "name": "victory_road_1f_room_2_entrance",
+        "access_rules": [
+            "@victory_road_1f_room_1, ^$soft_defog",
+            "@victory_road_1f_room_2, ^$soft_defog"
         ]
     },
     {
         "name": "victory_road_1f_room_2",
         "access_rules": [
-            "@victory_road_1f_room_1",
-            "@victory_road_1f_room_3"
+            "@victory_road_1f_room_2_entrance, ^$soft_defog, $strength",
+            "@victory_road_1f_room_3, ^$soft_defog"
         ]
     },
     {
@@ -3437,7 +3476,7 @@
     {
         "name": "victory_road_2f",
         "access_rules": [
-            "@victory_road_1f",
+            "@victory_road_2f_from_1f_strength, $rock_smash",
             "@victory_road_2f_entrance, $rock_smash, $strength"
         ]
     },
@@ -3451,7 +3490,15 @@
     {
         "name": "victory_road_b1f",
         "access_rules": [
-            "@victory_road_1f"
+            "@victory_road_1f_center",
+            "@Victory_road_b1f_upper"
+        ]
+    },
+        {
+        "name": "victory_road_b1f_upper",
+        "access_rules": [
+            "@victory_road_1f",
+            "@victory_road_b1f, $waterfall"
         ]
     },
     {

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -1303,7 +1303,7 @@
             {
                 "name": "1F - Item from Southern B1F Stairs",
                 "access_rules": [
-                    "@victory_road_b1f, $surf"
+                    "@victory_road_1f_center, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -2059,7 +2059,7 @@
                 "chest_unopened_img": "/images/locations/hidden.png",
                 "chest_opened_img": "/images/locations/hiddenopen.png",
                 "access_rules": [
-                    "@pokemon_league, ^$hidden"
+                    "@pokemon_league, $surf, $down_waterfall, ^$hidden"
                 ],
                 "visibility_rules": [
                     "show_items, opt_hidden_on"

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -1303,7 +1303,7 @@
             {
                 "name": "1F - Item from Southern B1F Stairs",
                 "access_rules": [
-                    "@victory_road_1f"
+                    "@victory_road_b1f, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"
@@ -1345,7 +1345,7 @@
                 "chest_unopened_img": "/images/locations/hidden.png",
                 "chest_opened_img": "/images/locations/hiddenopen.png",
                 "access_rules": [
-                    "@victory_road_1f, ^$hidden"
+                    "@victory_road_1f_center, ^$hidden"
                 ],
                 "visibility_rules": [
                     "show_items, opt_hidden_on"
@@ -1378,7 +1378,7 @@
             {
                 "name": "1F - Dragon Tamer Clinton",
                 "access_rules": [
-                    "@victory_road_1f"
+                    "@victory_road_1f_upper_entrance"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1389,7 +1389,7 @@
             {
                 "name": "1F - Black Belt Miles",
                 "access_rules": [
-                    "@victory_road_1f"
+                    "@victory_road_1f_center"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1400,7 +1400,7 @@
             {
                 "name": "2F - Item From Northern 1F Stairs",
                 "access_rules": [
-                    "@victory_road_2f"
+                    "@victory_road_2f_north_alcove, $strength"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"
@@ -1442,7 +1442,7 @@
                 "chest_unopened_img": "/images/locations/hidden.png",
                 "chest_opened_img": "/images/locations/hiddenopen.png",
                 "access_rules": [
-                    "@victory_road_2f, ^$hidden"
+                    "@victory_road_2f_from_1f_strength, ^$hidden"
                 ],
                 "visibility_rules": [
                     "show_items, opt_hidden_on"
@@ -1475,7 +1475,7 @@
             {
                 "name": "2F - Ace Trainer Sydney",
                 "access_rules": [
-                    "@victory_road_2f"
+                    "@victory_road_2f_from_1f_strength"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1497,7 +1497,7 @@
             {
                 "name": "2F - Veteran Clayton",
                 "access_rules": [
-                    "@victory_road_2f"
+                    "@victory_road_2f_from_1f"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1508,7 +1508,7 @@
             {
                 "name": "B1F - Item on Ledge",
                 "access_rules": [
-                    "@victory_road_b1f"
+                    "@victory_road_b1f_upper"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"
@@ -1518,7 +1518,7 @@
             {
                 "name": "B1F - Item in Top Right",
                 "access_rules": [
-                    "@victory_road_b1f"
+                    "@victory_road_b1f, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"
@@ -1528,7 +1528,7 @@
             {
                 "name": "B1F - Item in Bottom Right",
                 "access_rules": [
-                    "@victory_road_b1f"
+                    "@victory_road_b1f, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"
@@ -1540,7 +1540,7 @@
                 "chest_unopened_img": "/images/locations/hidden.png",
                 "chest_opened_img": "/images/locations/hiddenopen.png",
                 "access_rules": [
-                    "@victory_road_b1f, ^$hidden"
+                    "@victory_road_b1f, $surf, ^$hidden"
                 ],
                 "visibility_rules": [
                     "show_items, opt_hidden_on"
@@ -1552,7 +1552,7 @@
                 "chest_unopened_img": "/images/locations/hidden.png",
                 "chest_opened_img": "/images/locations/hiddenopen.png",
                 "access_rules": [
-                    "@victory_road_b1f, ^$hidden"
+                    "@victory_road_b1f_upper, ^$hidden"
                 ],
                 "visibility_rules": [
                     "show_items, opt_hidden_on"
@@ -1562,7 +1562,7 @@
             {
                 "name": "B1F - Ace Trainer Henry",
                 "access_rules": [
-                    "@victory_road_b1f"
+                    "@victory_road_b1f, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1573,7 +1573,7 @@
             {
                 "name": "B1F - Dragon Tamer Ondrej",
                 "access_rules": [
-                    "@victory_road_b1f"
+                    "@victory_road_b1f_upper"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1584,7 +1584,7 @@
             {
                 "name": "B1F - Psychic Valencia",
                 "access_rules": [
-                    "@victory_road_b1f"
+                    "@victory_road_b1f, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1595,7 +1595,7 @@
             {
                 "name": "B1F - Double Team Jo And Pat",
                 "access_rules": [
-                    "@victory_road_b1f"
+                    "@victory_road_b1f, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -1873,7 +1873,8 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@victory_road_1f_entrance, ^$land_encounters"
+                    "@victory_road_1f_entrance, ^$land_encounters",
+					"@victory_road_1f_upper_entrance, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"
@@ -1885,7 +1886,9 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@victory_road_2f_entrance, ^$land_encounters"
+                    "@victory_road_2f_entrance, ^$land_encounters",
+					"@victory_road_2f_from_1f, ^$land_encounters",
+					"@victory_road_2f_north_alcove, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"
@@ -1957,7 +1960,7 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@victory_road_1f_room_2, ^$land_encounters"
+                    "@victory_road_1f_room_2_entrance, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -54,6 +54,13 @@ function waterfall()
     or (has("hm07waterfall") and has("beaconbadge"))
 end
 
+function down_waterfall()
+    if not has("bag") and not has("hmreader") then
+        return false
+    end
+    return has("hm07waterfall")
+end
+
 function rock_climb()
     if not has("bag") and not has("hmreader") then
         return false


### PR DESCRIPTION
I make no promise i did these correctly.

the side rooms do not need surf for any of their things because you need surf to enter VR from the top, and if you are coming through the bottom you need to go through b1f, which requires surf. b1f_upper -> b1f likewise does not have surf/waterfall requirements for the same reasoning. 

I also changed the encounters so that 1F's can be accessed from the entrance on either side. 2F's can be reached from either entrance, or its alcove. room_2 land encounters are from room_2_entrance (pre-partner) but surfing/fishing only become available after you finish the partner stuff, so those are in room_2. You cannot fish or surf with a partner. B1F remained the same because if you have access to B1F_upper, you have access to B1F. 

b1f had $surf added to all of it's locations. I wanted to keep the regions the same as the AP, but you could fly to pokemon_league_south without surf and get to the land encounters. Otherwise I would of made a b1f_entrance.

2F from 1F stuff was a bit confusing to figure out from the AP, so thats the section I'm mostly unsure if I did correctly.

I also moved all the trainers and locations to their new regions.