### PR TITLE
More ap parity

### DIFF
--- a/locations/access.json
+++ b/locations/access.json
@@ -2597,6 +2597,7 @@
             "@snowpoint_city_pokecenter_1f",
             "@snowpoint_city_west_house",
             "@snowpoint_temple_1f",
+            "@fight_area",
             "@canalave_city, $boat_canalave_snowpoint, ^$north_sinnoh_fly",
             "@pastoria_city, $boat_pastoria_snowpoint, ^$north_sinnoh_fly"
         ]

--- a/locations/access.json
+++ b/locations/access.json
@@ -2,7 +2,7 @@
     {
         "name": "acuity_cavern",
         "access_rules": [
-            "@lake_acuity"
+            "@lake_acuity, $surf"
         ]
     },
     {

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -7139,7 +7139,7 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@stark_mountain_room_1_entrance, ^$land_encounters"
+                    "@stark_mountain_room_1, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -7139,7 +7139,7 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@stark_mountain_room_1, ^$land_encounters"
+                    "@stark_mountain_room_1_entrance, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -7102,7 +7102,7 @@
             {
                 "name": "Entrance - Commander Mars",
                 "access_rules": [
-                    "@stark_mountain_room_1"
+                    "@stark_mountain_room_1_entrance"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -7113,7 +7113,7 @@
             {
                 "name": "Entrance - Commander Jupiter",
                 "access_rules": [
-                    "@stark_mountain_room_1"
+                    "@stark_mountain_room_1_entrance"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -18829,7 +18829,7 @@
                 "chest_unopened_img": "/images/locations/encounters/land.png",
                 "chest_opened_img": "/images/locations/encounters/land_cleared.png",
                 "access_rules": [
-                    "@lake_acuity, ^$land_encounters"
+                    "@lake_acuity, $surf, ^$land_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"
@@ -18841,7 +18841,7 @@
                 "chest_unopened_img": "/images/locations/encounters/night.png",
                 "chest_opened_img": "/images/locations/encounters/night_cleared.png",
                 "access_rules": [
-                    "@lake_acuity, ^$night_encounters"
+                    "@lake_acuity, $surf, ^$night_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"
@@ -18853,7 +18853,7 @@
                 "chest_unopened_img": "/images/locations/encounters/ruby.png",
                 "chest_opened_img": "/images/locations/encounters/ruby_cleared.png",
                 "access_rules": [
-                    "@lake_acuity, ^$ruby_encounters"
+                    "@lake_acuity, $surf, ^$ruby_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"
@@ -18865,7 +18865,7 @@
                 "chest_unopened_img": "/images/locations/encounters/sapphire.png",
                 "chest_opened_img": "/images/locations/encounters/sapphire_cleared.png",
                 "access_rules": [
-                    "@lake_acuity, ^$sapphire_encounters"
+                    "@lake_acuity, $surf, ^$sapphire_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"
@@ -18877,7 +18877,7 @@
                 "chest_unopened_img": "/images/locations/encounters/emerald.png",
                 "chest_opened_img": "/images/locations/encounters/emerald_cleared.png",
                 "access_rules": [
-                    "@lake_acuity, ^$emerald_encounters"
+                    "@lake_acuity, $surf, ^$emerald_encounters"
                 ],
                 "visibility_rules": [
                     "show_mons"

--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -18770,7 +18770,7 @@
             {
                 "name": "Lake - Item in NE Corner of Lake",
                 "access_rules": [
-                    "@lake_acuity"
+                    "@lake_acuity, $surf"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"


### PR DESCRIPTION
parity with 

https://github.com/ljtpetersen/platinum_archipelago/pull/77
https://github.com/ljtpetersen/platinum_archipelago/pull/76
https://github.com/ljtpetersen/platinum_archipelago/pull/71

also found an issue with encounters in stark mountain requiring room_1 rather than room_1_entrance. This previously did not matter until the boat options, and APworld is already correct