### PR TITLE
Hide the 'Item from Man in Shop' locations in Celestic Town when NPC gifts are off

### DIFF
--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -3941,7 +3941,7 @@
                     "@celestic_town"
                 ],
                 "visibility_rules": [
-                    "show_items",
+                    "show_items, opt_npcgifts_on"
                 ],
                 "item_count": 1
             },
@@ -3951,7 +3951,7 @@
                     "@celestic_town, $day"
                 ],
                 "visibility_rules": [
-                    "show_items",
+                    "show_items, opt_npcgifts_on"
                 ],
                 "item_count": 1
             },
@@ -3961,7 +3961,7 @@
                     "@celestic_town, $night"
                 ],
                 "visibility_rules": [
-                    "show_items",
+                    "show_items, opt_npcgifts_on"
                 ],
                 "item_count": 1
             },


### PR DESCRIPTION
These locations do not exist when NPC gifts aren't shuffled and have no inherent logical relevance that would warrant displaying them when vanilla, but they still appear in the tracker no matter which way the option is set.
This fixes them to no longer show in the tracker when NPC gifts aren't shuffled.