### PR TITLE
Simplify access rules for overworld map items

### DIFF
--- a/locations/overworldmap.json
+++ b/locations/overworldmap.json
@@ -7831,8 +7831,7 @@
             {
                 "name": "Item on Ledge Above Move Tutor",
                 "access_rules": [
-                    "@route_212_south, opt_pastoria_barriers_on, bicycle, $cut, bag",
-                    "@route_212_south, opt_pastoria_barriers_off, bicycle, $cut"
+                    "@route_212_south, bicycle, $cut, bag"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"
@@ -7842,8 +7841,7 @@
             {
                 "name": "Item Near Scientist Between Cut Trees",
                 "access_rules": [
-                    "@route_212_south, opt_pastoria_barriers_on, bicycle, $cut, bag",
-                    "@route_212_south, opt_pastoria_barriers_off, bicycle, $cut"
+                    "@route_212_south, bicycle, $cut, bag"
                 ],
                 "visibility_rules": [
                     "show_items, opt_overworld_on"
@@ -7987,8 +7985,7 @@
             {
                 "name": "Scientist Shaun",
                 "access_rules": [
-                    "@route_212_south, opt_pastoria_barriers_on, bicycle, $cut, bag",
-                    "@route_212_south, opt_pastoria_barriers_off, bicycle, $cut"
+                    "@route_212_south, bicycle, $cut, bag"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",
@@ -7999,8 +7996,7 @@
             {
                 "name": "Parasol Lady Sabrina",
                 "access_rules": [
-                    "@route_212_south, opt_pastoria_barriers_on, bicycle, $cut, bag",
-                    "@route_212_south, opt_pastoria_barriers_off, bicycle, $cut"
+                    "@route_212_south, bicycle, $cut, bag"
                 ],
                 "visibility_rules": [
                     "show_items, opt_trainer_full",


### PR DESCRIPTION
Parity with https://github.com/ljtpetersen/platinum_archipelago/pull/78

these 4 checks always require the bag. there is no method to get to them from a bike rack. Coming from 212 South-west, you need to traverse mud, which forces you off of the bike. Coming from pastoria, you need to go through the hotel on r213, which also forces you off, or you come through the boat, but it is impossible to ride a bike to either canalave or snowpoint without a bag. Canalave needs surf, and the snow around snowpoint forces you off. 

even the long shot of climbing distortion world to get to sendoff spring also does not work, surf is used in the climb